### PR TITLE
ci: linters and molecule tests

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,6 @@
 ---
 # [min, basic, moderate, safety, shared, production]
 profile: basic
+
+mock_roles:
+  - clickhouse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+---
+name: CI
+
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check only *.yml extension is used
+        run: find . -name '*.yaml' | grep -v .pre-commit-config.yaml && exit 1 || echo OK
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+          cache: pip
+          cache-dependency-path: ./requirements-test.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-test.txt
+
+      - name: Ansible lint
+        run: ansible-lint --offline --strict
+
+  molecule:
+    name: Molecule
+    runs-on: ubuntu-latest
+    needs: lint
+    strategy:
+      matrix:
+        distro:
+          - name: debian
+            version: "12"
+          - name: ubuntu
+            version: "22.04"
+          - name: ubuntu
+            version: "24.04"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+          cache: pip
+          cache-dependency-path: ./requirements-test.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-test.txt
+
+      - name: Molecule
+        run: DISTRO_NAME=${{ matrix.distro.name }} DISTRO_VER=${{ matrix.distro.version }} molecule test


### PR DESCRIPTION
Closes #1 

Added CI workflow which
- checks for .yaml extensions (supposing that only .yml is allowed)
- runs `ansible lint`
- runs molecule tests