### PR TITLE
ci: disable persist-credentials for actions/checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Check only *.yml extension is used
         run: find . -name '*.yaml' | grep -v .pre-commit-config.yaml && exit 1 || echo OK
@@ -51,6 +53,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
It is a possible security issue, see [1] for the reference.

  [1]: https://github.com/actions/checkout/issues/485