### PR TITLE
Fix --check for client package install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
             version: "22.04"
           - name: ubuntu
             version: "24.04"
+          - name: ubuntu
+            version: "24.04"
+            setup: client
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -67,4 +70,8 @@ jobs:
         run: pip install -r requirements-test.txt
 
       - name: Molecule
-        run: DISTRO_NAME=${{ matrix.distro.name }} DISTRO_VER=${{ matrix.distro.version }} molecule test
+        run:
+          DISTRO_NAME=${{ matrix.distro.name }}
+          DISTRO_VER=${{ matrix.distro.version }}
+          CLICKHOUSE_SETUP=${{ matrix.distro.setup }}
+          molecule test

--- a/molecule/default/inventory/group_vars/all.yml
+++ b/molecule/default/inventory/group_vars/all.yml
@@ -5,6 +5,7 @@ clickhouse_packages:
   - clickhouse-client
 
 clickhouse_version: "{{ lookup('env', 'CLICKHOUSE_VER') }}"
+clickhouse_setup: "{{ lookup('env', 'CLICKHOUSE_SETUP') }}"
 
 clickhouse_users:
   default:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -30,6 +30,7 @@ provisioner:
   name: ansible
   env:
     CLICKHOUSE_VER: ${CLICKHOUSE_VER:-'*'}
+    CLICKHOUSE_SETUP: ${CLICKHOUSE_SETUP:-'full'}
   inventory:
     links:
       group_vars: ./inventory/group_vars/

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -54,159 +54,162 @@
         result: ""
 
   tasks:
-    - name: Include role default variables
-      include_vars:
-        dir: ../../defaults/
-        extensions:
-          - yml
-        name: role_defaults
+    - name: Server tests
+      when: clickhouse_setup == "full"
+      block:
+        - name: Include role default variables
+          include_vars:
+            dir: ../../defaults/
+            extensions:
+              - yml
+            name: role_defaults
 
-    - name: Assert clickhouse user created
-      getent:
-        database: passwd
-        key: clickhouse
+        - name: Assert clickhouse user created
+          getent:
+            database: passwd
+            key: clickhouse
 
-    - name: Assert clickhouse group created
-      getent:
-        database: group
-        key: clickhouse
+        - name: Assert clickhouse group created
+          getent:
+            database: group
+            key: clickhouse
 
-    - name: Collect installed packages
-      package_facts:
-        manager: auto
+        - name: Collect installed packages
+          package_facts:
+            manager: auto
 
-    - name: Assert Clickhouse Packages
-      assert:
-        that:
-          - "'{{ item }}' in ansible_facts.packages"
-      loop: "{{ clickhouse_packages }}"
+        - name: Assert Clickhouse Packages
+          assert:
+            that:
+              - "'{{ item }}' in ansible_facts.packages"
+          loop: "{{ clickhouse_packages }}"
 
-    - name: Collect systemd services
-      service_facts:
+        - name: Collect systemd services
+          service_facts:
 
-    - name: Assert systemd unit is in running state
-      assert:
-        that:
-          - "ansible_facts.services['clickhouse-server.service'].status == 'enabled'"
-          - "ansible_facts.services['clickhouse-server.service'].state == 'running'"
+        - name: Assert systemd unit is in running state
+          assert:
+            that:
+              - "ansible_facts.services['clickhouse-server.service'].status == 'enabled'"
+              - "ansible_facts.services['clickhouse-server.service'].state == 'running'"
 
-    - name: Collect default role override files
-      find:
-        path: ../../templates/clickhouse-server/config.d/
-        patterns: "*.yml.j2"
-      delegate_to: localhost
-      register: default_role_overrides_files
+        - name: Collect default role override files
+          find:
+            path: ../../templates/clickhouse-server/config.d/
+            patterns: "*.yml.j2"
+          delegate_to: localhost
+          register: default_role_overrides_files
 
-    - name: Default role overrides
-      set_fact:
-        default_role_overrides: >
-          {{ default_role_overrides_files.files |
-              map(attribute='path') |
-              map('basename') |
-              map('replace', '.j2', '')
-          }}
+        - name: Default role overrides
+          set_fact:
+            default_role_overrides: >
+              {{ default_role_overrides_files.files |
+                  map(attribute='path') |
+                  map('basename') |
+                  map('replace', '.j2', '')
+              }}
 
-    - name: Assert role default overrides exist
-      include_tasks: ./helpers/assert_config_exists.yml
-      vars:
-        target_config_dir: /etc/clickhouse-server/config.d
-      with_items:
-        - "{{ default_role_overrides }}"
+        - name: Assert role default overrides exist
+          include_tasks: ./helpers/assert_config_exists.yml
+          vars:
+            target_config_dir: /etc/clickhouse-server/config.d
+          with_items:
+            - "{{ default_role_overrides }}"
 
-    - name: Collect user-defined config override files
-      find:
-        path: templates/config.d/
-        patterns: "*.yml.j2"
-      delegate_to: localhost
-      register: user_defined_config_overrides_files
+        - name: Collect user-defined config override files
+          find:
+            path: templates/config.d/
+            patterns: "*.yml.j2"
+          delegate_to: localhost
+          register: user_defined_config_overrides_files
 
-    - name: User-defined config overrides
-      set_fact:
-        user_defined_config_overrides: >
-          {{ user_defined_config_overrides_files.files |
-              map(attribute='path') |
-              map('basename') |
-              map('replace', '.j2', '')
-          }}
+        - name: User-defined config overrides
+          set_fact:
+            user_defined_config_overrides: >
+              {{ user_defined_config_overrides_files.files |
+                  map(attribute='path') |
+                  map('basename') |
+                  map('replace', '.j2', '')
+              }}
 
-    - name: Assert user-defined configuration overrides exist
-      include_tasks: ./helpers/assert_config_exists.yml
-      vars:
-        target_config_dir: /etc/clickhouse-server/config.d
-      with_items:
-        - "{{ user_defined_config_overrides }}"
+        - name: Assert user-defined configuration overrides exist
+          include_tasks: ./helpers/assert_config_exists.yml
+          vars:
+            target_config_dir: /etc/clickhouse-server/config.d
+          with_items:
+            - "{{ user_defined_config_overrides }}"
 
-    - name: Collect user-defined user override files
-      find:
-        path: templates/users.d/
-        patterns: "*.yml.j2"
-      delegate_to: localhost
-      register: user_defined_user_overrides_files
+        - name: Collect user-defined user override files
+          find:
+            path: templates/users.d/
+            patterns: "*.yml.j2"
+          delegate_to: localhost
+          register: user_defined_user_overrides_files
 
-    - name: User-defined user overrides
-      set_fact:
-        user_defined_user_overrides: >
-          {{ user_defined_user_overrides_files.files |
-              map(attribute='path') |
-              map('basename') |
-              map('replace', '.j2', '')
-          }}
+        - name: User-defined user overrides
+          set_fact:
+            user_defined_user_overrides: >
+              {{ user_defined_user_overrides_files.files |
+                  map(attribute='path') |
+                  map('basename') |
+                  map('replace', '.j2', '')
+              }}
 
-    - name: Assert user-defined configuration overrides exist
-      include_tasks: ./helpers/assert_config_exists.yml
-      vars:
-        target_config_dir: /etc/clickhouse-server/users.d
-      with_items:
-        - "{{ user_defined_user_overrides }}"
+        - name: Assert user-defined configuration overrides exist
+          include_tasks: ./helpers/assert_config_exists.yml
+          vars:
+            target_config_dir: /etc/clickhouse-server/users.d
+          with_items:
+            - "{{ user_defined_user_overrides }}"
 
-    - name: Assert configuration has been applied correctly
-      include_tasks: ./helpers/assert_query_result.yml
-      with_items:
-        - "{{ database_level_assertions }}"
+        - name: Assert configuration has been applied correctly
+          include_tasks: ./helpers/assert_query_result.yml
+          with_items:
+            - "{{ database_level_assertions }}"
 
-    - name: Assert HTTP interface ping returns 200
-      uri:
-        url: http://localhost:8123/ping
+        - name: Assert HTTP interface ping returns 200
+          uri:
+            url: http://localhost:8123/ping
 
-    - name: Assert Prometheus endpoint returns 200
-      uri:
-        url: http://localhost:9363/metrics
+        - name: Assert Prometheus endpoint returns 200
+          uri:
+            url: http://localhost:9363/metrics
 
-    - name: Assert preconfigured HTTP handlers return 200
-      uri:
-        url: http://localhost:8123/{{ item }}
-      with_items:
-        - metrics/dictionary
-        - metrics/rocksdb
-        - metrics/distribution_queue
+        - name: Assert preconfigured HTTP handlers return 200
+          uri:
+            url: http://localhost:8123/{{ item }}
+          with_items:
+            - metrics/dictionary
+            - metrics/rocksdb
+            - metrics/distribution_queue
 
-    - name: Assert all user defined handlers return 200
-      uri:
-        url: http://localhost:8123/{{ item }}
-      with_items:
-        - first_test_handler
-        - second_test_handler
-        - third_test_handler
+        - name: Assert all user defined handlers return 200
+          uri:
+            url: http://localhost:8123/{{ item }}
+          with_items:
+            - first_test_handler
+            - second_test_handler
+            - third_test_handler
 
-    - name: Assert server format schema is accessible
-      uri:
-        url: "http://localhost:8123/?format_schema=record:Record&query=select+1+key,'foo'+value+format+Protobuf"
+        - name: Assert server format schema is accessible
+          uri:
+            url: "http://localhost:8123/?format_schema=record:Record&query=select+1+key,'foo'+value+format+Protobuf"
 
-    - name: Assert client format schema is accessible
-      command: >
-        clickhouse-client --query "select 1 key, 'foo' value format Protobuf settings format_schema='record:Record'"
+        - name: Assert client format schema is accessible
+          command: >
+            clickhouse-client --query "select 1 key, 'foo' value format Protobuf settings format_schema='record:Record'"
 
-    - name: Assert no unexpected messages found in .err.log
-      command: >
-        grep -v \
-          -e 'Access(local_directory): File /var/lib/clickhouse/access/users.list doesn\'t exist' \
-          -e 'Access(local_directory): Recovering lists in directory /var/lib/clickhouse/access/' \
-          -e 'Available memory at server startup is too low' \
-          -e 'Delay accounting is not enabled' \
-          -e 'Integrity check of the executable skipped because the reference checksum could not be read' \
-          -e 'Linux is not using a fast clock source' \
-          -e 'Linux threads max count is too low' \
-          -e 'Linux transparent hugepages are set to "always"' \
-          /var/log/clickhouse-server/clickhouse-server.err.log
-      register: grep_result
-      failed_when: grep_result.rc != 1
+        - name: Assert no unexpected messages found in .err.log
+          command: >
+            grep -v \
+              -e 'Access(local_directory): File /var/lib/clickhouse/access/users.list doesn\'t exist' \
+              -e 'Access(local_directory): Recovering lists in directory /var/lib/clickhouse/access/' \
+              -e 'Available memory at server startup is too low' \
+              -e 'Delay accounting is not enabled' \
+              -e 'Integrity check of the executable skipped because the reference checksum could not be read' \
+              -e 'Linux is not using a fast clock source' \
+              -e 'Linux threads max count is too low' \
+              -e 'Linux transparent hugepages are set to "always"' \
+              /var/log/clickhouse-server/clickhouse-server.err.log
+          register: grep_result
+          failed_when: grep_result.rc != 1

--- a/tasks/install_repo.yml
+++ b/tasks/install_repo.yml
@@ -44,7 +44,6 @@
     name: >
       {{
         clickhouse_packages |
-        reject('equalto', 'clickhouse-client') |
         product([clickhouse_version | d('*')]) |
         map('join', '=')
       }}
@@ -61,7 +60,7 @@
     name: >
       {{
         clickhouse_packages |
-        select('equalto', 'clickhouse-client') |
+        select('in', ['clickhouse-client', 'clickhouse-common-static']) |
         product([clickhouse_version | d('*')]) |
         map('join', '=')
       }}
@@ -71,3 +70,4 @@
   retries: 5
   delay: 5
   until: clickhouse_apt_packages is success
+  when: clickhouse_setup == "client"

--- a/tasks/pre_configure.yml
+++ b/tasks/pre_configure.yml
@@ -260,7 +260,6 @@
         dest: "/etc/clickhouse-client/format_schemas/{{ item | basename }}"
         owner: root
         group: root
-      notify: restart-clickhouse
       loop: "{{ clickhouse_format_schema_files }}"
     - name: Deploy clickhouse-client configuration files
       template:


### PR DESCRIPTION
- Fix `--check` for client package install (when the client package already installed it requires the versions of `clickhouse-client` and `clickhouse-common-static` to match, since `clickhouse-common-static` is not installed in the same command as `clickhouse-client`, fix it by handling various `clickhouse_setup` in a separate tasks there), note however, that it tricky to add a test for this, since for this we need some package already installed, while for now we don't have such "complex" tests, so there will be not test for it (only basic, see below)
- Do not trigger restart-clickhouse on client format schema deploy (breaks `clickhouse_setup=client`)
- Add tests for `clickhouse_mode=client` on CI

Fixes: https://github.com/semrush/ansible-role-clickhouse/issues/18