### PR TITLE
Add tests for --check mode

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -20,3 +20,6 @@
   listen: restart-clickhouse
   register: clickhouse_restarted
   when: clickhouse_restart_on_changes
+  # Ignore non-existing service error in check mode
+  failed_when: clickhouse_restarted.failed and (not ansible_check_mode or not clickhouse_restarted.msg.startswith("Could not find the requested service"))
+  changed_when: clickhouse_restarted.changed or clickhouse_restarted.failed

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -34,3 +34,20 @@ provisioner:
   inventory:
     links:
       group_vars: ./inventory/group_vars/
+
+scenario:
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    # cover ansible --check as well
+    - check
+    - converge
+    - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,9 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Ensure python3-apt is installed (required for testing ansible --check)
+      apt:
+        name: python3-apt
+        state: present

--- a/tasks/install_repo.yml
+++ b/tasks/install_repo.yml
@@ -32,12 +32,6 @@
   retries: 5
   delay: 5
   until: apt_get_update is success
-  # make "Install ClickHouse packages" works correctly in --check mode we need
-  # to have this package in the system, otherwise it will fail when the pinned
-  # version updated.
-  check_mode: false
-  tags:
-    - molecule-idempotence-notest
 
 - name: Install ClickHouse packages
   apt:
@@ -54,6 +48,14 @@
   delay: 5
   until: clickhouse_apt_packages is success
   when: clickhouse_setup == "full"
+  # Ignore not found package errors in check mode
+  failed_when: |
+    clickhouse_apt_packages.failed and
+    (
+      not ansible_check_mode or
+      clickhouse_apt_packages.msg | regex_search("^(no package(\(s\))? matching|no available installation candidate)", ignorecase=True) == None
+    )
+  changed_when: clickhouse_apt_packages.changed or clickhouse_apt_packages.failed
 
 - name: Install ClickHouse client package
   apt:
@@ -71,3 +73,5 @@
   delay: 5
   until: clickhouse_apt_packages is success
   when: clickhouse_setup == "client"
+  failed_when: clickhouse_apt_packages.failed and (not ansible_check_mode or not clickhouse_apt_packages.msg.startswith('No package matching'))
+  changed_when: clickhouse_apt_packages.changed or clickhouse_apt_packages.failed

--- a/tasks/setup_systemd.yml
+++ b/tasks/setup_systemd.yml
@@ -3,6 +3,10 @@
   systemd:
     name: clickhouse-server.service
     enabled: yes
+  register: enable_service
+  # Ignore non-existing service error in check mode
+  failed_when: enable_service.failed and (not ansible_check_mode or not enable_service.msg.startswith("Could not find the requested service"))
+  changed_when: enable_service.changed or enable_service.failed
 
 - name: Notify handlers manually
   meta: flush_handlers


### PR DESCRIPTION
Fix all tasks to be compatible with `--check` mode and adjust default molecule scenarios to run `--check` as well.