### PR TITLE
Fix name in role description

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 galaxy_info:
   role_name: clickhouse
+  namespace: semrush
   author: ClickHouse Team <clickhouse-team@semrush.com>
   description: Next-gen ansible role for ClickHouse with YAML
   min_ansible_version: "2.8"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,6 +6,6 @@
   tasks:
     - name: Apply clickhouse role
       include_role:
-        name: clickhouse
+        name: semrush.clickhouse
       tags:
         - clickhouse_install


### PR DESCRIPTION
molecule test reports [1]:

    WARNING  Computed fully qualified role name of clickhouse does not follow current galaxy requirements.
    Please edit meta/main.yml and assure we can correctly determine full role name:

    galaxy_info:
    role_name: my_name  # if absent directory name hosting role is used instead
    namespace: my_galaxy_namespace  # if absent, author is used instead

  [1]: https://github.com/semrush/ansible-role-clickhouse/actions/runs/11680520443/job/32523748372