### PR TITLE
Support repository setup without apt-key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
     name: Molecule
     runs-on: ubuntu-latest
     needs: lint
+    env:
+      ANSIBLE_FORCE_COLOR: "true"
     strategy:
       matrix:
         distro:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
         distro:
           - name: debian
             version: "12"
+          - name: debian
+            version: "13"
           - name: ubuntu
             version: "22.04"
           - name: ubuntu
@@ -56,6 +58,8 @@ jobs:
           - name: ubuntu
             version: "24.04"
             clickhouse_version: "24.9.2.42"
+          - name: ubuntu
+            version: "26.04"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,12 +12,17 @@ clickhouse_delete_stale_files: true
 # clickhouse_version: ""
 
 # Apt repository configuration variables
-# Apt key may be loaded either from keyserver, or directly from URL
-# In case URL is specified, it has higher priority over loading from keyserver.
 clickhouse_apt_repo: deb https://packages.clickhouse.com/deb stable main
+
+# Apt key configuration.
+# When apt-key is available, a custom URL has higher priority over keyserver.
+# When apt-key is not available, a custom URL or the builtin key URL is used
+# with signed-by keyring.
 clickhouse_apt_repo_key: 8919F6BD2B48D754
 clickhouse_apt_keyserver: keyserver.ubuntu.com
+
 clickhouse_apt_repo_key_url: ""
+clickhouse_apt_repo_builtin_key_url: https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key
 
 clickhouse_packages:
   - clickhouse-server

--- a/tasks/install_repo.yml
+++ b/tasks/install_repo.yml
@@ -7,7 +7,13 @@
 # Due to this fact we don't need to check if ClickHouse service state,
 # therefore handler notifications are not required at this step.
 
-- name: ClickHouse Apt repository
+- name: Check apt-key availability
+  stat:
+    path: /usr/bin/apt-key
+  register: clickhouse_apt_key_utility
+
+- name: ClickHouse Apt repository with apt-key
+  when: clickhouse_apt_key_utility.stat.exists
   block:
     - name: Apt key from URL
       get_url:
@@ -24,6 +30,33 @@
       apt_repository:
         filename: clickhouse__ansible
         repo: "{{ clickhouse_apt_repo }}"
+
+- name: ClickHouse Apt repository with keyring
+  when: not clickhouse_apt_key_utility.stat.exists
+  block:
+    - name: Apt key from URL
+      get_url:
+        url: "{{ clickhouse_apt_repo_key_url | default('', true) or clickhouse_apt_repo_builtin_key_url }}"
+        dest: /usr/share/keyrings/clickhouse__ansible.asc
+        mode: "0644"
+
+    - name: Remove legacy Apt key file
+      file:
+        path: /etc/apt/trusted.gpg.d/clickhouse__ansible.asc
+        state: absent
+
+    - name: Validate Apt repository format
+      assert:
+        that:
+          - clickhouse_apt_repo.split() | length == 4
+        fail_msg: "clickhouse_apt_repo must use format: deb URI suite component"
+
+    - name: Apt repository signed-by keyring
+      apt_repository:
+        filename: clickhouse__ansible
+        repo: >-
+          {% set repo_parts = clickhouse_apt_repo.split() %}
+          {{ repo_parts[0] }} [signed-by=/usr/share/keyrings/clickhouse__ansible.asc] {{ repo_parts[1:] | join(' ') }}
 
 - name: Update Debian Repositories
   apt:


### PR DESCRIPTION
Depending on apt-key presence, repository setup now either uses the existing path, or downloads ascii armored key from the `clickhouse_apt_repo_key_url` (if not configured uses builtin url), and adds it as a "signed-by" apt repository options.