### PR TITLE
Fix password configuration in client config

### DIFF
--- a/Documentation/Advanced_Configuration.md
+++ b/Documentation/Advanced_Configuration.md
@@ -108,10 +108,10 @@ remote_servers:
         - node:
               - host: 127.1
                 port: 9000
-                password: {{ clickhouse_users_default }}
+                password: {{ clickhouse_users['default']['password'] }}
               - host: 127.2
                 port: 9000
-                password: {{ clickhouse_users_default }}
+                password: {{ clickhouse_users['default']['password'] }}
     dev_cluster_secure:
         - secret: STORE_THIS_IN_ANSIBLE_VAULT_VARIABLE
           node:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -210,6 +210,16 @@
           command: >
             clickhouse-client --query "select 1 key, 'foo' value format Protobuf settings format_schema='record:Record'"
 
+        - name: Assert readonly user can connect with plain password
+          command: >
+            clickhouse-client --user readonly --password readonlypass --query "select 1"
+
+        - name: Assert readonly user can connect with env password
+          command: >
+            clickhouse-client --user readonly --query "select 1"
+          environment:
+            CLICKHOUSE_PASSWORD: readonlypass
+
         - name: Assert no unexpected messages found in .err.log
           command: >
             grep -v \

--- a/templates/clickhouse-client/config.xml.j2
+++ b/templates/clickhouse-client/config.xml.j2
@@ -15,7 +15,7 @@
         - RL_PROMPT_END_IGNORE   (\002)
     -->
     <prompt_by_server_display_name>
-        <default>\x1b[01;32m{display_name}\x1b[0m \e[1;31m:)\e[0m </default>
+        <default>\x1b[01;32m{display_name}\x1b[0m</default>
     </prompt_by_server_display_name>
 
     <format_schema_path>/etc/clickhouse-client/format_schemas</format_schema_path>

--- a/templates/clickhouse-client/config.xml.j2
+++ b/templates/clickhouse-client/config.xml.j2
@@ -19,6 +19,4 @@
     </prompt_by_server_display_name>
 
     <format_schema_path>/etc/clickhouse-client/format_schemas</format_schema_path>
-
-    <password>{{ clickhouse_users_default|d('') }}</password>
 </config>


### PR DESCRIPTION
There is an undeclared variable that is used for setting default user password in client config. Since there is empty line set by default, it may prevent auth via environment variables (password in client config has a priority over envvar).

This change is backwards incompatible: previously set up client config files may have an actual default password, set with the `clickchouse_users_default` ansible variable, which will be unset.